### PR TITLE
Update gdal import to pull from osgeo module

### DIFF
--- a/rvt/multiproc.py
+++ b/rvt/multiproc.py
@@ -1,4 +1,4 @@
-import gdal
+from osgeo import gdal
 import rvt.vis
 import rvt.default
 import numpy as np


### PR DESCRIPTION
Changes gdal import in `rvt/multiproc.py` to the [recommended usage (since GDAL 3.1)](https://pypi.org/project/GDAL/#imports).  This resolves gdal import issues when using GDAL > 3.1 and matches the import syntax used in `rvt/default.py`.  This doesn't maintain backward compatibility with the global gdal import, however.