### PR TITLE
Rtv py mstp

### DIFF
--- a/_test_mstp.py
+++ b/_test_mstp.py
@@ -1,7 +1,10 @@
 import rvt.default
 import rvt.vis
+import rvt.blend_func
+import numpy as np
 
 
+# Prepare
 dem_path = r"test_data\TM1_564_146.tif"
 
 dem_dict = rvt.default.get_raster_arr(dem_path)
@@ -9,15 +12,37 @@ dem_arr = dem_dict["array"]
 dem_res = dem_dict["resolution"][0]
 dem_nodata = dem_dict["no_data"]
 
-output_e3mstp_path = "{}_{}.tif".format(dem_path.rstrip(".tif"), "mstp")
 default = rvt.default.DefaultValues()
+
 default.mstp_local_scale = (1, 5, 1)
 default.mstp_meso_scale = (5, 50, 5)
 default.mstp_broad_scale = (50, 500, 50)
 default.mstp_lightness = 1.2
-default.slrm_rad_cell = 10
 
+# Run visualization function
 rendered_image = rvt.vis.mstp(dem=dem_arr, no_data=dem_nodata)
 
-rvt.default.save_raster(src_raster_path=dem_path, out_raster_arr=rendered_image, out_raster_path=output_e3mstp_path,
-                        e_type=6)
+# # Save result (float32)
+# output_mstp_path = dem_path.replace(".tif", "_mstp_float.tif")
+# rvt.default.save_raster(src_raster_path=dem_path, out_raster_arr=rendered_image, out_raster_path=output_mstp_path,
+#                         e_type=6)
+
+# Save 8-bit
+output_mstp_path_8bit = dem_path.replace(".tif", "_mstp_8bit2.tif")
+# # Can skip this as data is already between 0 and 1
+# norm_arr = rvt.blend_func.normalize_image(
+#                 visualization="mstp",
+#                 image=rendered_image,
+#                 min_norm=0,
+#                 max_norm=1,
+#                 normalization="value"
+#             )
+# Convert to 8 bit
+image_8bit = rvt.vis.byte_scale(data=rendered_image, no_data=np.nan, c_min=0, c_max=1)
+rvt.default.save_raster(src_raster_path=dem_path, out_raster_path=output_mstp_path_8bit, out_raster_arr=image_8bit,
+                        no_data=np.nan, e_type=1)  # e_type has to be 1 because visualization is 8-bit (0-255)
+
+# # Try saving as 8bit using the default method
+# default.mstp_save_float = False
+# default.mstp_save_8bit = True
+# default.save_mstp(dem_path)

--- a/_test_mstp.py
+++ b/_test_mstp.py
@@ -1,0 +1,23 @@
+import rvt.default
+import rvt.vis
+
+
+dem_path = r"test_data\TM1_564_146.tif"
+
+dem_dict = rvt.default.get_raster_arr(dem_path)
+dem_arr = dem_dict["array"]
+dem_res = dem_dict["resolution"][0]
+dem_nodata = dem_dict["no_data"]
+
+output_e3mstp_path = "{}_{}.tif".format(dem_path.rstrip(".tif"), "mstp")
+default = rvt.default.DefaultValues()
+default.mstp_local_scale = (1, 5, 1)
+default.mstp_meso_scale = (5, 50, 5)
+default.mstp_broad_scale = (50, 500, 50)
+default.mstp_lightness = 1.2
+default.slrm_rad_cell = 10
+
+rendered_image = rvt.vis.mstp(dem=dem_arr, no_data=dem_nodata)
+
+rvt.default.save_raster(src_raster_path=dem_path, out_raster_arr=rendered_image, out_raster_path=output_e3mstp_path,
+                        e_type=6)

--- a/docs/releases_rvtpy.rst
+++ b/docs/releases_rvtpy.rst
@@ -6,7 +6,7 @@ Python package release history
 UNRELEASED
 ----------
 *   Added 1 pixel edge padding before the calculation of hillshade and slope, to avoid no data edge in the final results.
-
+*   Added float option for MSTP visualization.
 
 2.1.0
 -----

--- a/rvt/blend.py
+++ b/rvt/blend.py
@@ -547,7 +547,9 @@ class BlenderCombination:
                         norm_image = normalize_image(visualization, image, min_norm, max_norm, normalization)
                 elif self.layers[i_img].vis.lower() == "multi-scale topographic position":
                     if save_visualizations:
-                        default.save_mstp(dem_path=self.dem_path, custom_dir=save_render_directory)
+                        default.save_mstp(
+                            dem_path=self.dem_path, custom_dir=save_render_directory, save_float=True, save_8bit=False
+                        )
                         image_path = default.get_mstp_path(self.dem_path)
                         norm_image = normalize_image(visualization, rvt.default.get_raster_arr(image_path)["array"],
                                                      min_norm, max_norm, normalization)

--- a/rvt/blend.py
+++ b/rvt/blend.py
@@ -1323,9 +1323,9 @@ def e3mstp(dem, resolution, default: rvt.default.DefaultValues = rvt.default.Def
                                    minimum=0,
                                    maximum=1, blend_mode="soft_light", opacity=70,
                                    image=crim_red_arr)
-    blend_combination.create_layer(vis_method="mstp", normalization="value",
-                                   minimum=0,
-                                   maximum=255, blend_mode="normal", opacity=100,
+    blend_combination.create_layer(vis_method="mstp",
+                                   normalization="value", minimum=0, maximum=1,
+                                   blend_mode="normal", opacity=100,
                                    image=mstp_arr)
     e3mstp_out = blend_combination.render_all_images()
     return e3mstp_out

--- a/rvt/default.py
+++ b/rvt/default.py
@@ -318,7 +318,7 @@ class DefaultValues:
         self.sim_bytscl = ("percent", 0.25, 0.00)
         self.ld_bytscl = ("value", 0.50, 1.80)
         self.msrm_bytscl = ("value", -2.50, 2.50)
-        self.mstp_bytscl = ("value", 0, 1)
+        self.mstp_bytscl = ("value", 0.00, 1.00)
         # tile
         self.tile_size_limit = 10000 * 10000  # if arr size > tile_size limit, it uses tile module
         self.tile_size = (4000, 4000)  # size of single tile when using tile module (x_size, y_size)
@@ -552,7 +552,15 @@ class DefaultValues:
                                                     " calculate maximum mean deviation from elevation."
                                                     " All have to be integers!"},
                 "mstp_lightness": {"value": self.mstp_lightness,
-                                   "description": "Lightness factor to adjust MSTP visibility."}
+                                   "description": "Lightness factor to adjust MSTP visibility."},
+                "mstp_save_float": {"value": self.mstp_save_float,
+                                  "description": "If 1 it saves float raster, if 0 it doesn't."},
+                "mstp_save_8bit": {"value": self.mstp_save_8bit,
+                                 "description": "If 1 it saves 8bit raster, if 0 it doesn't."},
+                "mstp_bytscl": {"mode": self.mstp_bytscl[0], "min": self.mstp_bytscl[1], "max": self.mstp_bytscl[2],
+                              "description": "Linear stretch and byte scale (0-255) for 8bit raster. "
+                                             "Mode can be 'value' or 'percent' (cut-off units). "
+                                             "Values min and max define stretch borders (in mode units)."}
             }
 
         }}
@@ -775,6 +783,11 @@ class DefaultValues:
                                      int(default_data["Multi-scale topographic position"]["mstp_broad_scale"]["max"]),
                                      int(default_data["Multi-scale topographic position"]["mstp_broad_scale"]["step"]))
             self.mstp_lightness = float(default_data["Multi-scale topographic position"]["mstp_lightness"]["value"])
+            self.mstp_save_float = int(default_data["Multi-scale topographic position"]["mstp_save_float"]["value"])
+            self.mstp_save_8bit = int(default_data["Multi-scale topographic position"]["mstp_save_8bit"]["value"])
+            self.mstp_bytscl = (str(default_data["Multi-scale topographic position"]["mstp_bytscl"]["mode"]),
+                              float(default_data["Multi-scale topographic position"]["mstp_bytscl"]["min"]),
+                              float(default_data["Multi-scale topographic position"]["mstp_bytscl"]["max"]))
             dat.close()
 
     def get_shadow_file_name(self, dem_path):

--- a/rvt/default.py
+++ b/rvt/default.py
@@ -294,6 +294,7 @@ class DefaultValues:
         self.sim_save_float = 1
         self.ld_save_float = 1
         self.msrm_save_float = 1
+        self.mstp_save_float = 1
         # save 8bit
         self.slp_save_8bit = 0
         self.hs_save_8bit = 0
@@ -304,6 +305,7 @@ class DefaultValues:
         self.sim_save_8bit = 0
         self.ld_save_8bit = 0
         self.msrm_save_8bit = 0
+        self.mstp_save_8bit = 0
         # 8-bit bytescale parameters
         self.slp_bytscl = ("value", 0.00, 51.00)
         self.hs_bytscl = ("value", 0.00, 1.00)
@@ -316,6 +318,7 @@ class DefaultValues:
         self.sim_bytscl = ("percent", 0.25, 0.00)
         self.ld_bytscl = ("value", 0.50, 1.80)
         self.msrm_bytscl = ("value", -2.50, 2.50)
+        self.mstp_bytscl = ("value", 0, 1)
         # tile
         self.tile_size_limit = 10000 * 10000  # if arr size > tile_size limit, it uses tile module
         self.tile_size = (4000, 4000)  # size of single tile when using tile module (x_size, y_size)
@@ -977,15 +980,26 @@ class DefaultValues:
         dem_path) and adds dem directory (dem_path) to it. If bit8 it returns 8bit file path."""
         return os.path.normpath(os.path.join(os.path.dirname(dem_path), self.get_msrm_file_name(dem_path, bit8)))
 
-    def get_mstp_file_name(self, dem_path):
+    def get_mstp_file_name(self, dem_path, bit8=False):
         """Returns Multi-scale topographic position name, dem name (from dem_path) with added mstp parameters.
         If bit8 it returns 8bit file name."""
         dem_name = os.path.basename(dem_path).split(".")[0]  # base name without extension
-        return "{}_MSTP_{}_{}_{}_L{}.tif".format(dem_name, self.mstp_local_scale[1], self.mstp_meso_scale[1],
-                                                 self.mstp_broad_scale[1], self.mstp_lightness)
 
-    def get_mstp_path(self, dem_path):
-        return os.path.normpath(os.path.join(os.path.dirname(dem_path), self.get_mstp_file_name(dem_path)))
+        mstp_file_name = "{}_MSTP_{}_{}_{}_L{}.tif".format(
+            dem_name,
+            self.mstp_local_scale[1],
+            self.mstp_meso_scale[1],
+            self.mstp_broad_scale[1],
+            self.mstp_lightness
+        )
+
+        if bit8:
+            mstp_file_name = mstp_file_name.replace(".tif", "_8bit.tif")
+
+        return mstp_file_name
+
+    def get_mstp_path(self, dem_path, bit8=False):
+        return os.path.normpath(os.path.join(os.path.dirname(dem_path), self.get_mstp_file_name(dem_path, bit8)))
 
     def get_visualization_file_name(self,
                                     rvt_visualization: RVTVisualization,
@@ -1162,7 +1176,16 @@ class DefaultValues:
                                                       normalization=self.msrm_bytscl[0])
             return rvt.vis.byte_scale(data=norm_arr, no_data=np.nan, c_min=0, c_max=1)
         elif visualization == RVTVisualization.MULTI_SCALE_TOPOGRAPHIC_POSITION:
-            return float_arr
+            # This might not be necessary, as all mstp data should already be between 0 and 1
+            norm_arr = rvt.blend_func.normalize_image(
+                visualization="mstp",
+                image=float_arr,
+                min_norm=self.mstp_bytscl[1],
+                max_norm=self.mstp_bytscl[2],
+                normalization=self.mstp_bytscl[0]
+            )
+
+            return rvt.vis.byte_scale(data=norm_arr, no_data=np.nan, c_min=0, c_max=1)
         else:
             raise Exception("rvt.default.DefaultValues.float_to_8bit: Wrong visualization (visualization) parameter!")
 
@@ -2025,19 +2048,42 @@ class DefaultValues:
                                 broad_scale=self.mstp_broad_scale, lightness=self.mstp_lightness, no_data=no_data)
         return mstp_arr
 
-    def save_mstp(self, dem_path, custom_dir=None):
+    def save_mstp(self, dem_path, custom_dir=None, save_float=None, save_8bit=None):
         """Calculates and saves Multi-scale topographic position from dem (dem_path) with default parameters.
         If custom_dir is None it saves in dem directory else in custom_dir. If path to file already exists we can
         overwrite file (overwrite=1) or not (overwrite=0)."""
+
+        # if save_float is None it takes boolean from default (self)
+        if save_float is None:
+            save_float = self.mstp_save_float
+        # if save_8bit is None it takes boolean from default (self)
+        if save_8bit is None:
+            save_8bit = self.mstp_save_8bit
+
+        if not save_float and not save_8bit:
+            raise Exception("rvt.default.DefaultValues.save_mstp: Both save_float and save_8bit are False,"
+                            " at least one of them has to be True!")
+
         if not os.path.isfile(dem_path):
-            raise Exception("rvt.default.DefaultValues.save_msrm: dem_path doesn't exist!")
+            raise Exception("rvt.default.DefaultValues.save_mstp: dem_path doesn't exist!")
+
         if custom_dir is None:
             mstp_path = self.get_mstp_path(dem_path)
+            mstp_8bit_path = self.get_mstp_path(dem_path, bit8=True)
         else:
             mstp_path = os.path.join(custom_dir, self.get_mstp_file_name(dem_path))
+            mstp_8bit_path = os.path.join(custom_dir, self.get_mstp_file_name(dem_path, bit8=True))
 
-        if os.path.isfile(mstp_path) and not self.overwrite:
-            return 0
+        # if file already exists and overwrite=0
+        if save_float and save_8bit:
+            if os.path.isfile(mstp_8bit_path) and os.path.isfile(mstp_path) and not self.overwrite:
+                return 0
+        elif save_float and not save_8bit:
+            if os.path.isfile(mstp_path) and not self.overwrite:
+                return 0
+        elif not save_float and not save_8bit:
+            if os.path.isfile(mstp_8bit_path) and not self.overwrite:
+                return 0
 
         dem_size = get_raster_size(raster_path=dem_path)
         if dem_size[0] * dem_size[1] > self.tile_size_limit:  # tile by tile calculation
@@ -2048,8 +2094,8 @@ class DefaultValues:
                 rvt_default=self,
                 dem_path=Path(dem_path),
                 output_dir_path=Path(custom_dir),
-                save_float=False,
-                save_8bit=True
+                save_float=save_float,
+                save_8bit=save_8bit
             )
             return 1
         else:  # singleprocess
@@ -2057,9 +2103,35 @@ class DefaultValues:
             dem_arr = dict_arr_res["array"]
             no_data = dict_arr_res["no_data"]
 
-            mstp_arr = self.get_mstp(dem_arr=dem_arr, no_data=no_data).astype('float32')
-            save_raster(src_raster_path=dem_path, out_raster_path=mstp_path, out_raster_arr=mstp_arr,
-                        e_type=1)
+            mstp_arr = self.get_mstp(dem_arr=dem_arr, no_data=no_data)
+
+            if save_float:
+                if os.path.isfile(mstp_path) and not self.overwrite:  # file exists and overwrite=0
+                    pass
+                else:
+                    save_raster(
+                        src_raster_path=dem_path,
+                        out_raster_path=mstp_path,
+                        out_raster_arr=mstp_arr,
+                        no_data=np.nan,
+                        e_type=6
+                    )
+            if save_8bit:
+                if os.path.isfile(mstp_8bit_path) and not self.overwrite:  # file exists and overwrite=0
+                    pass
+                else:
+                    slope_8bit_arr = self.float_to_8bit(
+                        float_arr=mstp_arr,
+                        visualization=RVTVisualization.MULTI_SCALE_TOPOGRAPHIC_POSITION
+                    )
+                    save_raster(
+                        src_raster_path=dem_path,
+                        out_raster_path=mstp_8bit_path,
+                        out_raster_arr=slope_8bit_arr,
+                        no_data=np.nan,
+                        e_type=1
+                    )
+
             return 1
 
     def save_visualizations(self, dem_path, custom_dir=None):

--- a/settings/default_settings.json
+++ b/settings/default_settings.json
@@ -342,6 +342,20 @@
             "mstp_lightness": {
                 "value": 1.2,
                 "description": "Lightness factor to adjust MSTP visibility."
+            },
+            "mstp_save_float": {
+                "value": 1,
+                "description": "If 1 it saves float raster, if 0 it doesn't."
+            },
+            "mstp_save_8bit": {
+                "value": 0,
+                "description": "If 1 it saves 8bit raster, if 0 it doesn't."
+            },
+            "mstp_bytscl": {
+                "mode": "value",
+                "min": 0.0,
+                "max": 1.0,
+                "description": "Linear stretch and byte scale (0-255) for 8bit raster. Mode can be 'value' or 'percent' (cut-off units). Values min and max define stretch borders (in mode units)."
             }
         }
     }


### PR DESCRIPTION
Pri uporabi RVT-ja smo naleteli na nekaj težav pri izdelavi MSTP vizualizacij.

MSTP je imel do zdaj kot edini možen output samo RGB image z vrednostmi med 0-255. Če si vizualizacijo izdelal direktno z funkcijo iz rvt.vis, je bil dtype output arraya float64. Ker sem to funkcijo na tak način uporabil pri enem trenutnem projektu (brez da bi predhodno to opazil), je količina podatkov zelo hitro narastla. Spremembe sem probal čimbolje dokumentirat v commitih na GitHubu, vseeno pa povzetek:

- rvt.vis.mstp() zdaj po defaultu vrže ven rezultat z vrednostmi med 0 in 1, pri čimer je dtype float32
- update-al sem vrednosti normalizacije  pri blendanju e3MSTP
- v rvt.default sem pripravil vse potrebno za shranjevanje MSTP-ja kot float ali 8bit (self.mstp_save_float, self.mstp_save_8bit)
- popravke sem testiral s skripto _test_mstp.py, ki je tudi dodana v repozitorij

Zdaj je MSTP usklajen z preostalimi vizualizacijami. Bo pa to potrebno upoštevat tudi pri pluginih za ArcGIS in QGIS. Popraviti bo verjetno treba tudi primer v Jupyter Notebooku "rvt_vis_example.ipynb".